### PR TITLE
[info](config): .markdownlint.yml

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -3,3 +3,9 @@
 MD033:
   # Allowed elements
   allowed_elements: [br]
+
+# MD013/Line length : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md013.md
+# 2024-20-08 @RalphHightower — pass on headings, tables
+MD013:
+  headings: false
+  tables: false


### PR DESCRIPTION
- skip line length checks on heading, tables